### PR TITLE
CI workflow update.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       -
         name: Get tag
         id: get_tag
-        run: echo "::set-output name=tag::$(git describe --tags HEAD)"
+        run: echo "tag=$(git describe --tags HEAD)" >> $GITHUB_OUTPUT
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Updated the CI workflow to use the GITHUB_OUTPUT environment file instead of the set-output command, in compliance with the latest best practices for GitHub Actions.