### PR TITLE
Added support for ARMv7 and ARMv8 architectures.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v8
           push: true
           tags: |
             ${{ github.repository }}:${{ steps.get_tag.outputs.tag }},


### PR DESCRIPTION
Updated the platforms list in the CI workflow to include support for linux/arm/v7 and linux/arm/v8 architectures, in addition to the existing linux/amd64 and linux/arm64 architectures. This change will allow building and pushing multi-architecture Docker images that can run on a wider range of devices, including certain Raspberry Pi models.