### PR TITLE
Added support for ARMv7 and ARMv8 architectures.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:3.10-slim AS build-stage
+FROM python:alpine3.17 AS build-stage
 LABEL maintainer="Andreas Violaris"
 COPY app /app
 WORKDIR /app
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM gcr.io/distroless/python3
-ENV PYTHONPATH=/usr/local/lib/python3.10/site-packages
+FROM python:alpine3.17
+ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
 COPY --from=build-stage $PYTHONPATH $PYTHONPATH
 COPY --from=build-stage /app /app
 WORKDIR /app


### PR DESCRIPTION
Replaced the Google Distroless Python image with the Alpine 3.17-based Python image to ensure compatibility with ARMv7 and ARMv8 architectures. Retained two build stages for potential future use.